### PR TITLE
Fix typo in bulk create employee controller - Backend

### DIFF
--- a/backend/src/controllers/employee.ts
+++ b/backend/src/controllers/employee.ts
@@ -101,7 +101,7 @@ async function bulkCreateEmployees(req: Request, res: Response) {
     if (employeesToCreate.length === 0) {
       return res.status(304);
     }
-    const newEmployees = await EmployeeRepo.createEmployee(
+    const newEmployees = await EmployeeRepo.bulkCreateEmployees(
       employeesToCreate.map((toCreate: any) =>
         _.pick(toCreate, ["firstName", "lastName", "salary"])
       )


### PR DESCRIPTION
 ## tl;dr
PreviousLy when you try to create a new row in the employee table, the server would return a 500 response code. This is because there is a typo in the bulk create employee controller function, where it is calling the `createEmployee` repository function (which does not accept) rather than the `bulkCreateEmployees` function. This PR makes the simple fix of switching the function being called. 

TODO: the controller should have better typing to help prevent this sort of issues going forward. 

## Testing Instructions
Test by adding new employees using the frontend UI. Watch the network logs and ensure the server doesn't run into error. Ensure that the new employees are created in the database. 

## Type of  change
- [x] Bug fix
